### PR TITLE
fix: mutate screen object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ testingLibrary.screen = Object.entries(testingLibrary.screen).reduce(
         return val;
       },
     }),
-  testingLibrary.screen
+  { ...testingLibrary.screen }
 );
 
 export const {


### PR DESCRIPTION
Issue: #3 

Before, @storybook/testing-library was patching the original screen object from testing-library dom.
Now it mutates it so there is no clash when running it on node.