### PR TITLE
chore: upgrade libs to be aligned with current stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@storybook/client-logger": "6.4.0-rc.5",
-    "@storybook/instrumenter": "6.4.0-rc.5",
+    "@storybook/client-logger": "^6.4.0",
+    "@storybook/instrumenter": "^6.4.0",
     "@testing-library/dom": "^8.3.0",
     "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"


### PR DESCRIPTION
# Issue

We are using this library with storybook 6.4.0 stable and it works well but it download 6.4.0-rc.

yarn why @storybook/instrumenter gave me

```
=> Found "@storybook/instrumenter@6.4.0-rc.5"
info Reasons this module exists
   - "_project_#@talend#design-system#@storybook#testing-library" depends on it
   - Hoisted from "_project_#@talend#design-system#@storybook#testing-library#@storybook#instrumenter"
info Disk size without dependencies: "2.05MB"
info Disk size with unique dependencies: "2.42MB"
info Disk size with transitive dependencies: "37.83MB"
info Number of shared dependencies: 86
=> Found "@storybook/addon-interactions#@storybook/instrumenter@6.4.9"
info This module exists because "_project_#@talend#design-system#@storybook#addon-interactions" depends on it.
```

# Solution

add caret version pointing to stable release.