### PR TITLE
deps: allow storybook 6.5 prerelease versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@storybook/client-logger": "^6.4.0",
-    "@storybook/instrumenter": "^6.4.0",
+    "@storybook/client-logger": "^6.4.0 || >=6.5.0-0",
+    "@storybook/instrumenter": "^6.4.0 || >=6.5.0-0",
     "@testing-library/dom": "^8.3.0",
     "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"


### PR DESCRIPTION
## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.9--canary.13.01cc4fe.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-library@0.0.9--canary.13.01cc4fe.0
  # or 
  yarn add @storybook/testing-library@0.0.9--canary.13.01cc4fe.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
