### PR TITLE
Revert "feat: upgrade testing library and user event"

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@storybook/client-logger": "^6.4.0 || >=6.5.0-0",
     "@storybook/instrumenter": "^6.4.0 || >=6.5.0-0",
-    "@testing-library/dom": "^8.13.0",
-    "@testing-library/user-event": "^14.1.1",
+    "@testing-library/dom": "^8.3.0",
+    "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit cfe0c8fe0a8e4658d4fd3157d1a8d245d18e1661.

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Release Notes

Unfortunately `@storybook/testing-library` had to downgrade `@testing-library/user-event` to version 13. User event v14 is working ok for most projects, but projects using Svelte, Vue, HTML and Web components break because of an issue in one of user-event's dependencies.

If you are not affected by this problem and want to use `@storybook/testing-library` with user-event v14, you can use the `@storybook/testing-library@beta` version.