### PR TITLE
loosen version ranges of storybook so we can start bench testing 7.0.0 alpha releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@storybook/client-logger": "^6.4.0 || >=6.5.0-0",
-    "@storybook/instrumenter": "^6.4.0 || >=6.5.0-0",
+    "@storybook/client-logger": "*",
+    "@storybook/instrumenter": "*",
     "@testing-library/dom": "^8.3.0",
     "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@storybook/client-logger": "*",
-    "@storybook/instrumenter": "*",
+    "@storybook/client-logger": "^6 || ^7 || ^7.0.0-0",
+    "@storybook/instrumenter": "^6 || ^7 || ^7.0.0-0",
     "@testing-library/dom": "^8.3.0",
     "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"


### PR DESCRIPTION
loosen the version ranges of storybook packages

## Change Type

Indicate the type of change your pull request is:

- [x] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.12--canary.21.bbe3341.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-library@0.0.12--canary.21.bbe3341.0
  # or 
  yarn add @storybook/testing-library@0.0.12--canary.21.bbe3341.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
