### PR TITLE
Fix dependency of @storybook/instrumenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@storybook/client-logger": "^6 || ^7 || ^7.0.0-0",
-    "@storybook/instrumenter": "^6 || ^7 || ^7.0.0-0",
+    "@storybook/client-logger": "^6.4.0",
+    "@storybook/instrumenter": "^6.4.0",
     "@testing-library/dom": "^8.3.0",
     "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"


### PR DESCRIPTION
This PR reverts #21. It was causing Storybook 6.4 projects to install the @storybook/instrumenter package version 7.0.0 which has an incompatible setting for now

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
