### PR TITLE
Make `waitFor` interceptable and don't override interval/timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,27 +4,11 @@ import * as domTestingLibrary from '@testing-library/dom';
 import _userEvent from '@testing-library/user-event';
 import dedent from 'ts-dedent';
 
-const debugOptions = {
-  timeout: 2147483647, // max valid timeout duration
-  interval: 2147483647,
-};
-
 const testingLibrary = instrument(
   { ...domTestingLibrary },
   {
-    intercept: (method, path) => path[0] === 'fireEvent' || method.startsWith('findBy'),
-    getArgs: (call, state) => {
-      if (!state.isDebugging) return call.args;
-      if (call.method.startsWith('findBy')) {
-        const [value, queryOptions, waitForOptions] = call.args;
-        return [value, queryOptions, { ...waitForOptions, ...debugOptions }];
-      }
-      if (call.method.startsWith('waitFor')) {
-        const [callback, options] = call.args;
-        return [callback, { ...options, ...debugOptions }];
-      }
-      return call.args;
-    },
+    intercept: (method, path) =>
+      path[0] === 'fireEvent' || method.startsWith('findBy') || method.startsWith('waitFor'),
   }
 );
 


### PR DESCRIPTION
Works in tandem with https://github.com/storybookjs/storybook/pull/18460

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.14--canary.23.51ebb1b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-library@0.0.14--canary.23.51ebb1b.0
  # or 
  yarn add @storybook/testing-library@0.0.14--canary.23.51ebb1b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
