### PR TITLE
support storybook 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,22 +27,26 @@
     "access": "public"
   },
   "dependencies": {
-    "@storybook/client-logger": "^6.4.0",
-    "@storybook/instrumenter": "^6.4.0",
+    "@storybook/client-logger": "next",
+    "@storybook/instrumenter": "next",
     "@testing-library/dom": "^8.3.0",
     "@testing-library/user-event": "^13.2.1",
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
-    "@auto-it/first-time-contributor": "^10.32.6",
-    "@auto-it/released": "^10.32.6",
+    "@auto-it/first-time-contributor": "^10.37.6",
+    "@auto-it/released": "^10.37.6",
     "@storybook/linter-config": "^3.1.2",
     "@types/react": "*",
-    "auto": "^10.32.6",
+    "auto": "^10.37.6",
     "rimraf": "^3.0.2",
     "typescript": "^4.4.3"
   },
   "auto": {
+    "prereleaseBranches": [
+      "next",
+      "prerelease"
+    ],
     "plugins": [
       "npm",
       "first-time-contributor",


### PR DESCRIPTION
This PR introduces a new prerelease strategy and Storybook 7.0 support for the `next` version of this library

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.14--canary.30.5f44d14.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-library@0.0.14--canary.30.5f44d14.0
  # or 
  yarn add @storybook/testing-library@0.0.14--canary.30.5f44d14.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
