### PR TITLE
chore: bump @testing-library/user-event from v13 to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@storybook/client-logger": "^6.4.0",
     "@storybook/instrumenter": "^6.4.0",
     "@testing-library/dom": "^8.3.0",
-    "@testing-library/user-event": "^13.2.1",
+    "@testing-library/user-event": "^14.4.3",
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Change Type
Bumps to v14 user-event support #26 as 13 is no longer being maintained.

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
