### PR TITLE
Change Storybook dependencies from `future` npm tag to `next`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
-    "@storybook/client-logger": "future",
-    "@storybook/instrumenter": "future",
+    "@storybook/client-logger": "next",
+    "@storybook/instrumenter": "next",
     "@auto-it/first-time-contributor": "^10.37.6",
     "@auto-it/released": "^10.37.6",
     "@storybook/linter-config": "^3.1.2",


### PR DESCRIPTION
Maintenance work, Storybook core dependencies are referring to next now instead of future.

# Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
