### PR TITLE
Lower testing library dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@testing-library/dom": "^9.3.1",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/dom": "^9.0.0",
+    "@testing-library/user-event": "^14.0.0",
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
For maximum compatibility
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.1--canary.47.8dafbde.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/testing-library@0.1.1--canary.47.8dafbde.0
  # or 
  yarn add @storybook/testing-library@0.1.1--canary.47.8dafbde.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
